### PR TITLE
Install requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+beautifulsoup4==4.9.1
+lxml==4.5.2
+pyotp==2.4.0
+selenium==3.141.0
+soupsieve==2.0.1
+urllib3==1.25.10


### PR DESCRIPTION
Add a `requirements.txt` so people can just `pip install -r requirements.txt`. Also has the benefit of making sure all dependencies always work with this project, forever.