### PR TITLE
Unable to click 'Get' button due to being obsured (?) + Fix detection of post-buying game page

### DIFF
--- a/Free_Games.py
+++ b/Free_Games.py
@@ -96,7 +96,7 @@ def getGame():
                 print("Still waiting - Possible captcha requiring completion")
                 has_warned_captcha = True
                 
-            if wait_until_xpath_visible("//*[contains(text(), 'Thank you for buying')]", 1):
+            if wait_until_xpath_visible("//*[contains(text(), 'Thank you for buying') or contains(text(), 'Got Epic Games')]", 1):
                 break
             
             time.sleep(1)

--- a/Free_Games.py
+++ b/Free_Games.py
@@ -66,11 +66,18 @@ def getGame():
         print("Already owned")
         return
     
-    if not wait_until_xpath_clickable_then_click("//*[text() = 'Get']"):
-        raise TypeError("Unable to find 'Get' button")
+    try:
+        if not wait_until_xpath_clickable_then_click("//*[text() = 'Get']"):
+            raise TypeError("Unable to find 'Get' button")
+    except:
+        print("Failed to click on 'Get' button. Using parent element workaround... ", end='')
+        if not wait_until_xpath_clickable_then_click("//*[text() = 'Get']/.."):
+            raise TypeError("Workaround failed")
+        else:
+            print("Worked")
     if not wait_until_xpath_clickable_then_click("//*[text() = 'Place Order']"):
         raise TypeError("Unable to find 'Place Order' button")
-    
+        
     # Wait until redirected to "THANK YOU" page
     wait_redirect_count = 0
     has_warned_captcha = False


### PR DESCRIPTION
Ran into those two issues when trying to claim games today.
Somehow it fails to click on the 'Get' button complaining that the parent obscures it. The fix here is to simply click the parent if that happens. So far this issue only happened with this specific button.

+ They apparently changed the text on the buying confirmation page. Updated the string to match it.